### PR TITLE
Fix incorrect layout xml block directive - should be refernce

### DIFF
--- a/src/app/design/frontend/default/default/layout/fontis/recaptcha.xml
+++ b/src/app/design/frontend/default/default/layout/fontis/recaptcha.xml
@@ -52,8 +52,8 @@
     </customer_account_create>
 
     <review_product_list>
-        <block name="product.review.form" >
-            <block type="core/template" name="recaptcha.box" as="recaptcha_box" template="fontis/recaptcha/recaptcha.phtml"/>
-        </block>
+		<reference name="product.review.form" >
+			<block type="core/template" name="recaptcha.box" as="recaptcha_box" template="fontis/recaptcha/recaptcha.phtml"/>
+		</reference>
     </review_product_list>
 </layout>


### PR DESCRIPTION
Layout directive incorrectly uses block, should be reference
this causes an exception of review form load.

exception 'Mage_Core_Exception' with message 'Invalid block type: ' in /home/lucas/workspace/sites/mysite/app/Mage.php:594
